### PR TITLE
PCL profile 328 version of LibJpeg.NET

### DIFF
--- a/LibJpeg.NET.sln
+++ b/LibJpeg.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE689AB8-58B7-4816-88F0-DA4C201A2B42}"
 	ProjectSection(SolutionItems) = preProject
@@ -38,6 +38,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibJpeg.Silverlight", "LibJ
 		{7300CDF5-1C93-4611-8CC9-47FE79F340AB} = {7300CDF5-1C93-4611-8CC9-47FE79F340AB}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibJpeg.Portable", "LibJpeg.Portable\LibJpeg.Portable.csproj", "{305A25DA-BA3E-4403-ADF1-536F44CFD813}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +70,10 @@ Global
 		{297AC639-8A6C-43D1-A3FF-01D8A79C4090}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{297AC639-8A6C-43D1-A3FF-01D8A79C4090}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{297AC639-8A6C-43D1-A3FF-01D8A79C4090}.Release|Any CPU.Build.0 = Release|Any CPU
+		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LibJpeg.Portable/LibJpeg.Portable.csproj
+++ b/LibJpeg.Portable/LibJpeg.Portable.csproj
@@ -1,0 +1,276 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{305A25DA-BA3E-4403-ADF1-536F44CFD813}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BitMiracle.LibJpeg</RootNamespace>
+    <AssemblyName>BitMiracle.LibJpeg.Portable</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT EXPOSE_LIBJPEG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT EXPOSE_LIBJPEG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\LibJpeg\BitmapDestination.cs">
+      <Link>BitmapDestination.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\BitStream.cs">
+      <Link>BitStream.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\DensityUnit.cs">
+      <Link>Classic\DensityUnit.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_decoder.cs">
+      <Link>Classic\Internal\arith_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_encoder.cs">
+      <Link>Classic\Internal\arith_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\bitread_perm_state.cs">
+      <Link>Classic\Internal\bitread_perm_state.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\bitread_working_state.cs">
+      <Link>Classic\Internal\bitread_working_state.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\ComponentBuffer.cs">
+      <Link>Classic\Internal\ComponentBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\d_derived_tbl.cs">
+      <Link>Classic\Internal\d_derived_tbl.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\huff_entropy_decoder.cs">
+      <Link>Classic\Internal\huff_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\huff_entropy_encoder.cs">
+      <Link>Classic\Internal\huff_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\JpegUtils.cs">
+      <Link>Classic\Internal\JpegUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_converter.cs">
+      <Link>Classic\Internal\jpeg_color_converter.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_deconverter.cs">
+      <Link>Classic\Internal\jpeg_color_deconverter.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_quantizer.cs">
+      <Link>Classic\Internal\jpeg_color_quantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_comp_master.cs">
+      <Link>Classic\Internal\jpeg_comp_master.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_coef_controller.cs">
+      <Link>Classic\Internal\jpeg_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_main_controller.cs">
+      <Link>Classic\Internal\jpeg_c_main_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_prep_controller.cs">
+      <Link>Classic\Internal\jpeg_c_prep_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_decomp_master.cs">
+      <Link>Classic\Internal\jpeg_decomp_master.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_downsampler.cs">
+      <Link>Classic\Internal\jpeg_downsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_coef_controller.cs">
+      <Link>Classic\Internal\jpeg_d_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_main_controller.cs">
+      <Link>Classic\Internal\jpeg_d_main_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_post_controller.cs">
+      <Link>Classic\Internal\jpeg_d_post_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_entropy_decoder.cs">
+      <Link>Classic\Internal\jpeg_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_entropy_encoder.cs">
+      <Link>Classic\Internal\jpeg_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_forward_dct.cs">
+      <Link>Classic\Internal\jpeg_forward_dct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_input_controller.cs">
+      <Link>Classic\Internal\jpeg_input_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_inverse_dct.cs">
+      <Link>Classic\Internal\jpeg_inverse_dct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_marker_reader.cs">
+      <Link>Classic\Internal\jpeg_marker_reader.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_marker_writer.cs">
+      <Link>Classic\Internal\jpeg_marker_writer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_scan_info.cs">
+      <Link>Classic\Internal\jpeg_scan_info.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_upsampler.cs">
+      <Link>Classic\Internal\jpeg_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\J_BUF_MODE.cs">
+      <Link>Classic\Internal\J_BUF_MODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_1pass_cquantizer.cs">
+      <Link>Classic\Internal\my_1pass_cquantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_2pass_cquantizer.cs">
+      <Link>Classic\Internal\my_2pass_cquantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_c_coef_controller.cs">
+      <Link>Classic\Internal\my_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_destination_mgr.cs">
+      <Link>Classic\Internal\my_destination_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_merged_upsampler.cs">
+      <Link>Classic\Internal\my_merged_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_source_mgr.cs">
+      <Link>Classic\Internal\my_source_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_trans_c_coef_controller.cs">
+      <Link>Classic\Internal\my_trans_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_upsampler.cs">
+      <Link>Classic\Internal\my_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JBLOCK.cs">
+      <Link>Classic\JBLOCK.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JHUFF_TBL.cs">
+      <Link>Classic\JHUFF_TBL.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JpegConstants.cs">
+      <Link>Classic\JpegConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_common_struct.cs">
+      <Link>Classic\jpeg_common_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_component_info.cs">
+      <Link>Classic\jpeg_component_info.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_compress_struct.cs">
+      <Link>Classic\jpeg_compress_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_decompress_struct.cs">
+      <Link>Classic\jpeg_decompress_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_destination_mgr.cs">
+      <Link>Classic\jpeg_destination_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_error_mgr.cs">
+      <Link>Classic\jpeg_error_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JPEG_MARKER.cs">
+      <Link>Classic\JPEG_MARKER.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_marker_struct.cs">
+      <Link>Classic\jpeg_marker_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_progress_mgr.cs">
+      <Link>Classic\jpeg_progress_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_source_mgr.cs">
+      <Link>Classic\jpeg_source_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JQUANT_TBL.cs">
+      <Link>Classic\JQUANT_TBL.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jvirt_array.cs">
+      <Link>Classic\jvirt_array.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_COLOR_SPACE.cs">
+      <Link>Classic\J_COLOR_SPACE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_COLOR_TRANSFORM.cs">
+      <Link>Classic\J_COLOR_TRANSFORM.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_DCT_METHOD.cs">
+      <Link>Classic\J_DCT_METHOD.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_DITHER_MODE.cs">
+      <Link>Classic\J_DITHER_MODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_MESSAGE_CODE.cs">
+      <Link>Classic\J_MESSAGE_CODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\ReadResult.cs">
+      <Link>Classic\ReadResult.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\CompressionParameters.cs">
+      <Link>CompressionParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\DecompressionParameters.cs">
+      <Link>DecompressionParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\DecompressorToJpegImage.cs">
+      <Link>DecompressorToJpegImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Enumerations.cs">
+      <Link>Enumerations.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\IDecompressDestination.cs">
+      <Link>IDecompressDestination.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\IRawImage.cs">
+      <Link>IRawImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Jpeg.cs">
+      <Link>Jpeg.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\JpegImage.cs">
+      <Link>JpegImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\RawImage.cs">
+      <Link>RawImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Sample.cs">
+      <Link>Sample.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\SampleRow.cs">
+      <Link>SampleRow.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Utils.cs">
+      <Link>Utils.cs</Link>
+    </Compile>
+    <Compile Include="AssemblyVersion.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/LibJpeg.Portable/Properties/AssemblyInfo.cs
+++ b/LibJpeg.Portable/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+using System.Resources;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BitMiracle.LibJpeg.Portable")]
+[assembly: AssemblyDescription("PCL version of IJG's LibJpeg library made by Bit Miracle")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Bit Miracle")]
+[assembly: AssemblyProduct("BitMiracle.LibJpeg.Portable")]
+[assembly: AssemblyCopyright("Copyright (C) 2008-2016, Bit Miracle")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+[assembly: CLSCompliant(true)]

--- a/LibJpeg.Silverlight/LibJpeg.Silverlight.csproj
+++ b/LibJpeg.Silverlight/LibJpeg.Silverlight.csproj
@@ -68,6 +68,12 @@
     <Compile Include="..\LibJpeg\Classic\DensityUnit.cs">
       <Link>Classic\DensityUnit.cs</Link>
     </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_decoder.cs">
+      <Link>Classic\Internal\arith_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_encoder.cs">
+      <Link>Classic\Internal\arith_entropy_encoder.cs</Link>
+    </Compile>
     <Compile Include="..\LibJpeg\Classic\Internal\bitread_perm_state.cs">
       <Link>Classic\Internal\bitread_perm_state.cs</Link>
     </Compile>
@@ -179,12 +185,6 @@
     <Compile Include="..\LibJpeg\Classic\Internal\my_upsampler.cs">
       <Link>Classic\Internal\my_upsampler.cs</Link>
     </Compile>
-    <Compile Include="..\LibJpeg\Classic\Internal\phuff_entropy_decoder.cs">
-      <Link>Classic\Internal\phuff_entropy_decoder.cs</Link>
-    </Compile>
-    <Compile Include="..\LibJpeg\Classic\Internal\phuff_entropy_encoder.cs">
-      <Link>Classic\Internal\phuff_entropy_encoder.cs</Link>
-    </Compile>
     <Compile Include="..\LibJpeg\Classic\JBLOCK.cs">
       <Link>Classic\JBLOCK.cs</Link>
     </Compile>
@@ -232,6 +232,9 @@
     </Compile>
     <Compile Include="..\LibJpeg\Classic\J_COLOR_SPACE.cs">
       <Link>Classic\J_COLOR_SPACE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_COLOR_TRANSFORM.cs">
+      <Link>Classic\J_COLOR_TRANSFORM.cs</Link>
     </Compile>
     <Compile Include="..\LibJpeg\Classic\J_DCT_METHOD.cs">
       <Link>Classic\J_DCT_METHOD.cs</Link>

--- a/LibJpeg/Classic/jpeg_decompress_struct.cs
+++ b/LibJpeg/Classic/jpeg_decompress_struct.cs
@@ -305,7 +305,7 @@ namespace BitMiracle.LibJpeg.Classic
         {
             get
             {
-                return m_marker_list.AsReadOnly();
+                return new ReadOnlyCollection<jpeg_marker_struct>(m_marker_list);
             }
         }
 

--- a/LibJpeg/Classic/jpeg_error_mgr.cs
+++ b/LibJpeg/Classic/jpeg_error_mgr.cs
@@ -8,6 +8,10 @@
 using System;
 using System.Globalization;
 
+#if SILVERLIGHT
+using Console = System.Diagnostics.Debug;
+#endif
+
 namespace BitMiracle.LibJpeg.Classic
 {
     /// <summary>

--- a/LibJpeg/JpegImage.cs
+++ b/LibJpeg/JpegImage.cs
@@ -82,6 +82,7 @@ namespace BitMiracle.LibJpeg
             createFromStream(imageData);
         }
 
+#if !SILVERLIGHT
         /// <summary>
         /// Creates <see cref="JpegImage"/> from file with an arbitrary image
         /// </summary>
@@ -95,6 +96,7 @@ namespace BitMiracle.LibJpeg
             using (FileStream input = new FileStream(fileName, FileMode.Open))
                 createFromStream(input);
         }
+#endif
 
         /// <summary>
         /// Creates <see cref="JpegImage"/> from pixels


### PR DESCRIPTION
Many thanks for an excellent work in providing a fully managed JPEG codec library!

I have noticed that you are providing a scaled-down Silverlight version of _LibJpeg.NET_. Based on the SL version, I have now set up a Profile 328 Portable Class Library, simultaneously targeting:
- .NET Framework 4 and later
- Silverlight 5
- Windows Phone Silverlight 8 and later
- Windows Phone 8.1
- Windows 8 and later, including Universal Windows Platform
- Xamarin Android
- Xamarin iOS (Classic and Unified)

I have reused the SILVERLIGHT compiler directive to minimize the source code changes for now. There were only very marginal modifications that were needed to ensure that the PCL project would compile, namely:
- Exclude `JpegImage(string)` constructor overload from PCL / Silverlight builds since `FileStream` is not defined in PCL,
- Explicitly use `ReadOnlyCollection` constructor to create read-only `MarkerList` in `jpeg_decompress_struct` since `List<T>.AsReadOnly()` is not available in PCL, and
- Log `jpeg_error_mgr` errors to `Debug` instead of `Console` in PCL / Silverlight builds since `Console` is not defined in PCL.

Before adding the PCL project to the _LibJpeg.NET_ solution, I also updated the Silverlight project since it seemed to be out-of-date in relation to the latest changes in the main _LibJpeg_ project.

I hope you find these minor additions worthwhile to include in the main repository.

Anders @ Cureos
