### PR TITLE
Add build for NetStandard 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ AssemblyVersion.cs
 # Test outputs
 TestCase/Output/*.bmp
 TestCase/Output/*.jpg
+/LibJpeg.NetStandard/project.lock.json

--- a/LibJpeg.NET.sln
+++ b/LibJpeg.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE689AB8-58B7-4816-88F0-DA4C201A2B42}"
 	ProjectSection(SolutionItems) = preProject
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibJpeg.Silverlight", "LibJ
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibJpeg.Portable", "LibJpeg.Portable\LibJpeg.Portable.csproj", "{305A25DA-BA3E-4403-ADF1-536F44CFD813}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibJpeg.NetStandard", "LibJpeg.Netstandard\LibJpeg.NetStandard.csproj", "{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,10 @@ Global
 		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{305A25DA-BA3E-4403-ADF1-536F44CFD813}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LibJpeg.NetStandard/LibJpeg.NetStandard.csproj
+++ b/LibJpeg.NetStandard/LibJpeg.NetStandard.csproj
@@ -1,0 +1,282 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E8DB7BDC-60CD-46B3-9D14-16B41F08305C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BitMiracle.LibJpeg</RootNamespace>
+    <AssemblyName>BitMiracle.LibJpeg.NetStandard</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD SILVERLIGHT EXPOSE_LIBJPEG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT EXPOSE_LIBJPEG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\LibJpeg\BitmapDestination.cs">
+      <Link>BitmapDestination.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\BitStream.cs">
+      <Link>BitStream.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\DensityUnit.cs">
+      <Link>Classic\DensityUnit.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_decoder.cs">
+      <Link>Classic\Internal\arith_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\arith_entropy_encoder.cs">
+      <Link>Classic\Internal\arith_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\bitread_perm_state.cs">
+      <Link>Classic\Internal\bitread_perm_state.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\bitread_working_state.cs">
+      <Link>Classic\Internal\bitread_working_state.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\ComponentBuffer.cs">
+      <Link>Classic\Internal\ComponentBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\d_derived_tbl.cs">
+      <Link>Classic\Internal\d_derived_tbl.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\huff_entropy_decoder.cs">
+      <Link>Classic\Internal\huff_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\huff_entropy_encoder.cs">
+      <Link>Classic\Internal\huff_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\JpegUtils.cs">
+      <Link>Classic\Internal\JpegUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_converter.cs">
+      <Link>Classic\Internal\jpeg_color_converter.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_deconverter.cs">
+      <Link>Classic\Internal\jpeg_color_deconverter.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_color_quantizer.cs">
+      <Link>Classic\Internal\jpeg_color_quantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_comp_master.cs">
+      <Link>Classic\Internal\jpeg_comp_master.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_coef_controller.cs">
+      <Link>Classic\Internal\jpeg_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_main_controller.cs">
+      <Link>Classic\Internal\jpeg_c_main_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_c_prep_controller.cs">
+      <Link>Classic\Internal\jpeg_c_prep_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_decomp_master.cs">
+      <Link>Classic\Internal\jpeg_decomp_master.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_downsampler.cs">
+      <Link>Classic\Internal\jpeg_downsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_coef_controller.cs">
+      <Link>Classic\Internal\jpeg_d_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_main_controller.cs">
+      <Link>Classic\Internal\jpeg_d_main_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_d_post_controller.cs">
+      <Link>Classic\Internal\jpeg_d_post_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_entropy_decoder.cs">
+      <Link>Classic\Internal\jpeg_entropy_decoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_entropy_encoder.cs">
+      <Link>Classic\Internal\jpeg_entropy_encoder.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_forward_dct.cs">
+      <Link>Classic\Internal\jpeg_forward_dct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_input_controller.cs">
+      <Link>Classic\Internal\jpeg_input_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_inverse_dct.cs">
+      <Link>Classic\Internal\jpeg_inverse_dct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_marker_reader.cs">
+      <Link>Classic\Internal\jpeg_marker_reader.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_marker_writer.cs">
+      <Link>Classic\Internal\jpeg_marker_writer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_scan_info.cs">
+      <Link>Classic\Internal\jpeg_scan_info.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\jpeg_upsampler.cs">
+      <Link>Classic\Internal\jpeg_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\J_BUF_MODE.cs">
+      <Link>Classic\Internal\J_BUF_MODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_1pass_cquantizer.cs">
+      <Link>Classic\Internal\my_1pass_cquantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_2pass_cquantizer.cs">
+      <Link>Classic\Internal\my_2pass_cquantizer.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_c_coef_controller.cs">
+      <Link>Classic\Internal\my_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_destination_mgr.cs">
+      <Link>Classic\Internal\my_destination_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_merged_upsampler.cs">
+      <Link>Classic\Internal\my_merged_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_source_mgr.cs">
+      <Link>Classic\Internal\my_source_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_trans_c_coef_controller.cs">
+      <Link>Classic\Internal\my_trans_c_coef_controller.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\Internal\my_upsampler.cs">
+      <Link>Classic\Internal\my_upsampler.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JBLOCK.cs">
+      <Link>Classic\JBLOCK.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JHUFF_TBL.cs">
+      <Link>Classic\JHUFF_TBL.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JpegConstants.cs">
+      <Link>Classic\JpegConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_common_struct.cs">
+      <Link>Classic\jpeg_common_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_component_info.cs">
+      <Link>Classic\jpeg_component_info.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_compress_struct.cs">
+      <Link>Classic\jpeg_compress_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_decompress_struct.cs">
+      <Link>Classic\jpeg_decompress_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_destination_mgr.cs">
+      <Link>Classic\jpeg_destination_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_error_mgr.cs">
+      <Link>Classic\jpeg_error_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JPEG_MARKER.cs">
+      <Link>Classic\JPEG_MARKER.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_marker_struct.cs">
+      <Link>Classic\jpeg_marker_struct.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_progress_mgr.cs">
+      <Link>Classic\jpeg_progress_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jpeg_source_mgr.cs">
+      <Link>Classic\jpeg_source_mgr.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\JQUANT_TBL.cs">
+      <Link>Classic\JQUANT_TBL.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\jvirt_array.cs">
+      <Link>Classic\jvirt_array.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_COLOR_SPACE.cs">
+      <Link>Classic\J_COLOR_SPACE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_COLOR_TRANSFORM.cs">
+      <Link>Classic\J_COLOR_TRANSFORM.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_DCT_METHOD.cs">
+      <Link>Classic\J_DCT_METHOD.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_DITHER_MODE.cs">
+      <Link>Classic\J_DITHER_MODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\J_MESSAGE_CODE.cs">
+      <Link>Classic\J_MESSAGE_CODE.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Classic\ReadResult.cs">
+      <Link>Classic\ReadResult.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\CompressionParameters.cs">
+      <Link>CompressionParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\DecompressionParameters.cs">
+      <Link>DecompressionParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\DecompressorToJpegImage.cs">
+      <Link>DecompressorToJpegImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Enumerations.cs">
+      <Link>Enumerations.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\IDecompressDestination.cs">
+      <Link>IDecompressDestination.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\IRawImage.cs">
+      <Link>IRawImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Jpeg.cs">
+      <Link>Jpeg.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\JpegImage.cs">
+      <Link>JpegImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\RawImage.cs">
+      <Link>RawImage.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Sample.cs">
+      <Link>Sample.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\SampleRow.cs">
+      <Link>SampleRow.cs</Link>
+    </Compile>
+    <Compile Include="..\LibJpeg\Utils.cs">
+      <Link>Utils.cs</Link>
+    </Compile>
+    <Compile Include="AssemblyVersion.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>cd "$(SolutionDir)"
+update_version_info.bat "$(ProjectDir)AssemblyVersion.cs"</PreBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/LibJpeg.NetStandard/project.json
+++ b/LibJpeg.NetStandard/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/LibJpeg/Classic/jpeg_common_struct.cs
+++ b/LibJpeg/Classic/jpeg_common_struct.cs
@@ -128,7 +128,11 @@ namespace BitMiracle.LibJpeg.Classic
         {
             get
             {
+#if NETSTANDARD
+                AssemblyName assemblyName = new AssemblyName(typeof(jpeg_common_struct).GetTypeInfo().FullName);
+#else
                 AssemblyName assemblyName = new AssemblyName(Assembly.GetExecutingAssembly().FullName);
+#endif
                 Version version = assemblyName.Version;
                 string versionString = version.Major.ToString(CultureInfo.InvariantCulture) +
                     "." + version.Minor.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
This PR adds a build for NetStandard 1.0, which can be used in any of the platforms outlined [here](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/net-platform-standard.md#mapping-the-net-platform-standard-to-platforms) including .NET Core.

Thanks for all of your effort on this library!
